### PR TITLE
Enable passing arguments via main options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,42 @@ gulp.task('test', function () {
 Default is `casperjs` (global)
 
 
+## Options
+
+It is possible to pass casperjs options via main options object.
+
+```js
+var casperJs = require('gulp-casperjs');
+gulp.task('casperCmd', function () {
+  const options = {
+    logLevel: 'debug',
+    includes: 'node_modules/package/index.js,node_modules/pacakge2/index.js',
+    webSecurity: 'no'
+  };
+  gulp.src('test.js')
+    .pipe(casperJs(options)); //run casperjs test.js
+});
+```
+
+Options are documented in official CasperJS documentation http://docs.casperjs.org
+Possible values are
+
+| Option      | Parameter Name | Possible Values                  |
+|-------------|----------------|----------------------------------|
+| concise     | --concise      |                                  |
+| engine      | --engine       | [phantomjs | slimerjs]           |
+| failFast    | --fail-fast    |                                  |
+| includes    | --includes     | <filename>,<filename>            |
+| logLevel    | --log-level    | [debug | info | warning | error] |
+| noColors    | --no-colors    |                                  |
+| post        | --post         | <filename>                       |
+| pre         | --pre          | <filename>                       |
+| webSecurity | --web-security | no                               |
+| xunit       | --xunit        | <filename>                       |
+
+
+
+
 ## LICENSE
 
 The MIT License (MIT)

--- a/index.js
+++ b/index.js
@@ -8,9 +8,50 @@ const PLUGIN_NAME = 'gulp-casper-js';
 function casper(options) {
     options = options || {};
 
-    var cmd = (typeof options.command === 'undefined') ? 'test' : options.command;
+    var args = [];
+
+    if (options.xunit) {
+        args.push('--xunit=' + options.xunit);
+    }
+
+    if (options.logLevel) {
+        args.push('--log-level=' + options.loglevel);
+    }
+
+    if (options.engine) {
+        args.push('--engine=' + options.engine);
+    }
+
+    if (options.includes) {
+        args.push('--includes=' + options.includes);
+    }
+
+    if (options.pre) {
+        args.push('--pre=' + options.pre);
+    }
+
+    if (options.post) {
+        args.push('--post=' + options.post);
+    }
+
+    if (options.failfast) {
+        args.push('--fail-fast=');
+    }
+
+    if (options.concise) {
+        args.push('--concise=');
+    }
+
+    if (options.nocolors) {
+        args.push('--no-colors');
+    }
+
+    if (options.websecurity) {
+        args.push('--web-security=' + options.websecurity);
+    }
 
     var binPath = (typeof options.binPath === 'undefined') ? 'casperjs' : options.binPath;
+    var cmd = (typeof options.command === 'undefined') ? 'test' : options.command;
 
     var files = [];
 
@@ -36,8 +77,13 @@ function casper(options) {
 
     var end = function(cb) {
         cmd = cmd ? (Array.isArray(cmd) ? cmd : cmd.split(' ')) : [];
+        var tempArr = cmd.concat(files);
 
-        var casperChild = spawn(binPath, cmd.concat(files));
+        if (args.length) {
+            tempArr = tempArr.concat(args);
+        }
+
+        var casperChild = spawn('casperjs', tempArr);
 
         casperChild.stdout.on('data', function(data) {
             var msg = data.toString().slice(0, -1);


### PR DESCRIPTION
I think it is usefull to add option to pass args via options object properties. Currently it is possible to directly set test command, which is set in string and can be hard to modify in runtime
```
var options = {
  command: 'test --web-security=no'
};
```

this PR adds option to pass it like this 

```
var options = {
   webSecurity: no,
   loglevel: 1,
   ...
};
```